### PR TITLE
linux/bf154052: fix -Woverflow warning

### DIFF
--- a/linux/bf154052f0eea4bc7712499e4569505907d15889.c
+++ b/linux/bf154052f0eea4bc7712499e4569505907d15889.c
@@ -53,7 +53,7 @@ void loop()
                  0xfffffffffffffffful, 0x0ul);
   memcpy((void*)0x2040aff5,
          "\x2f\x64\x65\x76\x2f\x6c\x6f\x6f\x70\x23\x00", 11);
-  r[2] = syz_open_dev(0x2040aff5ul, 0xfffffffffffffffeul, 0x1ul);
+  r[2] = syz_open_dev(0x2040aff5ul, 0xfffffffeul, 0x1ul);
   memcpy((void*)0x20614000, "\x74\x75\x6e\x08\x00\x00\x00\x00\x00\x00"
                             "\x00\x80\x00\x00\x00\x00",
          16);


### PR DESCRIPTION
> linux/bf154052f0eea4bc7712499e4569505907d15889.c: In function 'loop':
> linux/bf154052f0eea4bc7712499e4569505907d15889.c:56:37: warning: large integer implicitly truncated to unsigned type [-Woverflow]
>    r[2] = syz_open_dev(0x2040aff5ul, 0xfffffffffffffffeul, 0x1ul);

The reproducer is built with '-m32', so 0xfffffffffffffffe does not fit
into uintptr_t. Let us use a smaller value here.